### PR TITLE
Update README to reflect release of Arduino IDE 1.6.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Marlin 3D Printer Firmware
 <img align="top" width=175 src="Documentation/Logo/Marlin%20Logo%20GitHub.png" />
- Documentation has moved to the [wiki](https://github.com/MarlinFirmware/Marlin/wiki).
+ Documentation has moved to the [wiki](https://github.com/MarlinFirmware/MarlinDev/wiki).
 
 ## This is the source code which produces the Marlin Firmware
-In order to build the firmware, you will also need a build environment. The official build environment is based on the beta version of the [Arduino IDE 1.6.6 (Hourly Builds)](https://www.arduino.cc/Main/Software).
+In order to build the firmware, you will also need a build environment. The official build environment is based on the [Arduino IDE 1.6.6](https://www.arduino.cc/Main/Software).
 
 ## Development Only
 
@@ -29,10 +29,11 @@ Since the 1.1.0-RC2, the following changes have been made:
 
 ## Branches
 ### Development
-The [dev branch](https://github.com/MarlinFirmware/MarlinDev/tree/dev) contains the most up-to-date development Marlin code. Please remember that this code is for developers only and may well contain non-working situations. (Experimental) After downloading and installing the [Arduino IDE 1.6.6 (Hourly Builds)](https://www.arduino.cc/Main/Software), visit [Marlin Build Support](https://github.com/Wackerbarth/MarlinDev/tree/MarlinFirmware) for instructions on how the load the Marlin Platform support. Install this branch as the library mentioned in (1) above.
+The [dev branch](https://github.com/MarlinFirmware/MarlinDev/tree/dev) contains the most up-to-date development Marlin code. Please remember that this code is for developers only and may well contain non-working situations. Instructions for setting up the build environment and compiling the firmware can be found in our [wiki](https://github.com/MarlinFirmware/MarlinDev/wiki).
 
 ### Testing
 The [RC branch](https://github.com/MarlinFirmware/Marlin/tree/RC) contains the latest Marlin 1.1 pre-release candidate.
+The [RCBugFix branch](https://github.com/MarlinFirmware/Marlin/tree/RCBugFix) has some additional corrections which will be included in the next release candidate.
 
 ### Released Code
 For the latest tagged version of Marlin (currently 1.0.2 – January 2015) you should switch to the [Release Repository](https://github.com/MarlinFirmware/Marlin). Please see that repository for additional information.
@@ -79,8 +80,8 @@ More features have been added by:
 
 ## License
 
-Marlin is published under the [GPL license](/Documentation/COPYING.md) because we believe in open development. The GPL comes with both rights and obligations. Whether you use Marlin firmware as the driver for your open or closed-source product, you must keep Marlin open, and you must provide your compatible Marlin source code to end users upon request. The most straightforward way to comply with the Marlin license is to make a fork of Marlin on Github, perform your modifications, and direct users to your modified fork.
+Marlin is published under the [GPL v3 license](/LICENSE) because we believe in open development. The GPL comes with both rights and obligations. Whether you use Marlin firmware as the driver for your open or closed-source product, you must keep Marlin open, and you must provide your compatible Marlin source code to end users upon request. The most straightforward way to comply with the Marlin license is to make a fork of Marlin on Github, perform your modifications, and direct users to your modified fork.
 
 While we can't prevent the use of this code in products (3D printers, CNC, etc.) that are closed source or crippled by a patent, we would prefer that you choose another firmware or, better yet, make your own.
 
-[![Flattr this git repo](http://api.flattr.com/button/flattr-badge-large.png)](https://flattr.com/submit/auto?user_id=ErikZalm&url=https://github.com/MarlinFirmware/Marlin&title=Marlin&language=&tags=github&category=software)
+[![Flattr this git repo](http://api.flattr.com/button/flattr-badge-large.png)](https://flattr.com/submit/auto?user_id=ErikZalm&url=https://github.com/MarlinFirmware/MarlinDev&title=Marlin&language=&tags=github&category=software)


### PR DESCRIPTION
and creation of MarlinDev’s own wiki.